### PR TITLE
a2pico_synchandler: add manual hysteresis

### DIFF
--- a/a2pico.pio
+++ b/a2pico.pio
@@ -190,9 +190,11 @@ static inline void read_program_set_config(pio_sm_config *c) {
     mov x, osr                  // move OSR to X
 
 loop:
-    wait 0 gpio GPIO_PHI1       // wait for PHI1 to fall
+    wait 0 gpio GPIO_PHI1 [31]  // wait for PHI1 to fall
+    nop [31]
 
-    wait 1 gpio GPIO_PHI1       // wait for PHI1 to rise
+    wait 1 gpio GPIO_PHI1 [31]  // wait for PHI1 to rise
+    nop [31]
 
     jmp x-- loop                // jump to 'loop' if X != 0, prior to decrement
 


### PR DESCRIPTION
Apparently, there are false transitions on the PHI1 GPIO that the Pico SDK's hysteresis control are not enough to thwart. Add some nops to make things square.